### PR TITLE
Update parser to be compatible with PHP >= 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "paquettg/php-html-parser": "^1.7"
+    "paquettg/php-html-parser": "^2.1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
The current version of php-html-parser fails with modern PHP versions due to an incompatible regex. Fortunately, the maintainer has refactored and fixed the entire library this year.